### PR TITLE
Fix firefox popups

### DIFF
--- a/HaikuCompositor.cpp
+++ b/HaikuCompositor.cpp
@@ -244,6 +244,17 @@ void HaikuSurface::AttachView(BView *view)
 	view->AddChild(fView);
 }
 
+void HaikuSurface::AttachViewsToEarlierSubsurfaces()
+{
+	if (fView == NULL) {
+		fprintf(stderr, "[!] HaikuSurface::AttachViewsToEarlierSubsurfaces(): fView == NULL\n");
+		return;
+	}
+	for (HaikuSubsurface *subsurface = SurfaceList().First(); subsurface != NULL; subsurface = SurfaceList().GetNext(subsurface)) {
+		subsurface->Surface()->AttachView(fView);
+	}
+}
+
 void HaikuSurface::Detach()
 {
 	if (fView == NULL) {

--- a/HaikuCompositor.h
+++ b/HaikuCompositor.h
@@ -104,6 +104,7 @@ public:
 	HaikuSubsurface::SurfaceList &SurfaceList() {return fSurfaceList;}
 	void AttachWindow(BWindow *window);
 	void AttachView(BView *view);
+	void AttachViewsToEarlierSubsurfaces();
 	void Detach();
 	void Invalidate();
 	void CallFrameCallbacks();

--- a/HaikuSubcompositor.cpp
+++ b/HaikuSubcompositor.cpp
@@ -81,12 +81,18 @@ HaikuSubsurface *HaikuSubsurface::Create(struct wl_client *client, uint32_t vers
 	if (!subsurface->Init(client, version, id)) {
 		return NULL;
 	}
-	subsurface->fSurface = HaikuSurface::FromResource(surface);
-	subsurface->fSurface->fSubsurface = subsurface;
+	HaikuSurface *haikuSurface = HaikuSurface::FromResource(surface);
+	subsurface->fSurface = haikuSurface;
+	haikuSurface->fSubsurface = subsurface;
 	subsurface->fParent = HaikuSurface::FromResource(parent);
 	subsurface->fParent->SurfaceList().Insert(subsurface);
-	subsurface->fSurface->SetHook(new SubsurfaceHook());
-	subsurface->fSurface->AttachView(subsurface->fParent->View());
+	haikuSurface->SetHook(new SubsurfaceHook());
+	
+	BView *parentView = subsurface->fParent->View();
+	if (parentView) {
+		haikuSurface->AttachView(parentView);
+		haikuSurface->AttachViewsToEarlierSubsurfaces();
+	}
 	return subsurface;
 }
 

--- a/HaikuXdgPopup.cpp
+++ b/HaikuXdgPopup.cpp
@@ -80,6 +80,7 @@ HaikuXdgPopup *HaikuXdgPopup::Create(HaikuXdgSurface *xdgSurface, uint32_t id, s
 
 	xdgPopup->fWindow = new WaylandPopupWindow(xdgPopup, BRect(), "", B_NO_BORDER_WINDOW_LOOK, B_FLOATING_SUBSET_WINDOW_FEEL, B_AVOID_FOCUS);
 	xdgSurface->Surface()->AttachWindow(xdgPopup->fWindow);
+	xdgSurface->Surface()->AttachViewsToEarlierSubsurfaces();
 	xdgPopup->fWindow->AddToSubset(xdgPopup->fXdgSurface->fRoot->Window());
 
 	return xdgPopup;


### PR DESCRIPTION
- This fixes firefox popups doesn't display correctly on first time.
- The problem was subsurface's HaikuSurface::AttachView() called before their parent HaikuSurfaces' one. This happens when get_subsurface() before their parent wl_surface get a role (Subsurface or XDG Popup).
- I deferred AttachView() timing to when parent surface get those role (HaikuSubsurface::Create(), HaikuXdgPopup::Create()) by using SurfaceList().